### PR TITLE
Allow users of the gem to specify a logger object

### DIFF
--- a/lib/manageiq-postgres_ha_admin.rb
+++ b/lib/manageiq-postgres_ha_admin.rb
@@ -1,4 +1,20 @@
 require 'manageiq/postgres_ha_admin/version'
+
+require 'manageiq/postgres_ha_admin/logging'
+require 'manageiq/postgres_ha_admin/null_logger'
+
 require 'manageiq/postgres_ha_admin/database_yml'
 require 'manageiq/postgres_ha_admin/failover_databases'
 require 'manageiq/postgres_ha_admin/failover_monitor'
+
+module ManageIQ
+  module PostgresHaAdmin
+    class << self
+      attr_writer :logger
+    end
+
+    def self.logger
+      @logger ||= NullLogger.new
+    end
+  end
+end

--- a/lib/manageiq/postgres_ha_admin/failover_databases.rb
+++ b/lib/manageiq/postgres_ha_admin/failover_databases.rb
@@ -5,13 +5,14 @@ require 'pg/dsn_parser'
 module ManageIQ
 module PostgresHaAdmin
   class FailoverDatabases
+    include Logging
+
     TABLE_NAME = "repmgr.nodes".freeze
 
     attr_reader :yml_file
 
-    def initialize(yml_file, logger)
+    def initialize(yml_file)
       @yml_file = yml_file
-      @logger = logger
     end
 
     def active_databases_conninfo_hash
@@ -29,8 +30,8 @@ module PostgresHaAdmin
       arr_yml = query_repmgr(connection)
       File.write(yml_file, arr_yml.to_yaml) unless arr_yml.empty?
     rescue IOError => err
-      @logger.error("#{err.class}: #{err}")
-      @logger.error(err.backtrace.join("\n"))
+      logger.error("#{err.class}: #{err}")
+      logger.error(err.backtrace.join("\n"))
     end
 
     def host_is_repmgr_primary?(host, connection)
@@ -55,8 +56,8 @@ module PostgresHaAdmin
       db_result.clear
       result
     rescue PG::Error => err
-      @logger.error("#{err.class}: #{err}")
-      @logger.error(err.backtrace.join("\n"))
+      logger.error("#{err.class}: #{err}")
+      logger.error(err.backtrace.join("\n"))
       result
     end
 

--- a/lib/manageiq/postgres_ha_admin/failover_monitor.rb
+++ b/lib/manageiq/postgres_ha_admin/failover_monitor.rb
@@ -5,6 +5,8 @@ require 'linux_admin'
 module ManageIQ
 module PostgresHaAdmin
   class FailoverMonitor
+    include Logging
+
     RAILS_ROOT = [
       Pathname.new("/var/www/miq/vmdb"),
       Pathname.new(File.expand_path(File.join(__dir__, "../..")))
@@ -12,22 +14,14 @@ module PostgresHaAdmin
     FAILOVER_ATTEMPTS = 10
     DB_CHECK_FREQUENCY = 300
     FAILOVER_CHECK_FREQUENCY = 60
-    LOG_FILE = '/var/www/miq/vmdb/log/ha_admin.log'.freeze
     attr_accessor :failover_attempts, :db_check_frequency, :failover_check_frequency
 
     def initialize(db_yml_file: '/var/www/miq/vmdb/config/database.yml',
                    failover_yml_file: '/var/www/miq/vmdb/config/failover_databases.yml',
                    ha_admin_yml_file: '/var/www/miq/vmdb/config/ha_admin.yml',
-                   logger: nil,
                    environment: 'production')
-      if logger.respond_to?(:error, :info)
-        @logger = logger
-      else
-        @logger = Logger.new(LOG_FILE)
-        @logger.level = Logger::INFO
-      end
       @database_yml = DatabaseYml.new(db_yml_file, environment)
-      @failover_db = FailoverDatabases.new(failover_yml_file, @logger)
+      @failover_db = FailoverDatabases.new(failover_yml_file)
       initialize_settings(ha_admin_yml_file)
     end
 
@@ -39,14 +33,14 @@ module PostgresHaAdmin
         return
       end
 
-      @logger.error("Primary Database is not available. EVM server stop initiated. Starting to execute failover...")
+      logger.error("Primary Database is not available. EVM server stop initiated. Starting to execute failover...")
       stop_evmserverd
 
       if execute_failover
         start_evmserverd
         raise_failover_event
       else
-        @logger.error("Failover failed")
+        logger.error("Failover failed")
       end
     end
 
@@ -55,8 +49,8 @@ module PostgresHaAdmin
         begin
           monitor
         rescue => err
-          @logger.error("#{err.class}: #{err}")
-          @logger.error(err.backtrace.join("\n"))
+          logger.error("#{err.class}: #{err}")
+          logger.error(err.backtrace.join("\n"))
         end
         sleep(db_check_frequency)
       end
@@ -82,13 +76,13 @@ module PostgresHaAdmin
         ha_admin_yml = YAML.load_file(ha_admin_yml_file)
       rescue SystemCallError, IOError => err
         ha_admin_yml = {}
-        @logger.error("#{err.class}: #{err}")
-        @logger.info("File not loaded: #{ha_admin_yml_file}. Default settings for failover will be used.")
+        logger.error("#{err.class}: #{err}")
+        logger.info("File not loaded: #{ha_admin_yml_file}. Default settings for failover will be used.")
       end
       @failover_attempts = ha_admin_yml['failover_attempts'] || FAILOVER_ATTEMPTS
       @db_check_frequency = ha_admin_yml['db_check_frequency'] || DB_CHECK_FREQUENCY
       @failover_check_frequency = ha_admin_yml['failover_check_frequency'] || FAILOVER_CHECK_FREQUENCY
-      @logger.info("FAILOVER_ATTEMPTS=#{@failover_attempts} DB_CHECK_FREQUENCY=#{@db_check_frequency} FAILOVER_CHECK_FREQUENCY=#{@failover_check_frequency}")
+      logger.info("FAILOVER_ATTEMPTS=#{@failover_attempts} DB_CHECK_FREQUENCY=#{@db_check_frequency} FAILOVER_CHECK_FREQUENCY=#{@failover_check_frequency}")
     end
 
     def execute_failover
@@ -96,7 +90,7 @@ module PostgresHaAdmin
         with_each_standby_connection do |connection, params|
           next if database_in_recovery?(connection)
           next unless @failover_db.host_is_repmgr_primary?(params[:host], connection)
-          @logger.info("Failing over to server using conninfo: #{params.reject { |k, _v| k == :password }}")
+          logger.info("Failing over to server using conninfo: #{params.reject { |k, _v| k == :password }}")
           @failover_db.update_failover_yml(connection)
           @database_yml.update_database_yml(params)
           return true
@@ -121,13 +115,13 @@ module PostgresHaAdmin
     def pg_connection(params)
       PG::Connection.open(params)
     rescue PG::Error => e
-      @logger.error("Failed to establish PG connection: #{e.message}")
+      logger.error("Failed to establish PG connection: #{e.message}")
       nil
     end
 
     def start_evmserverd
       LinuxAdmin::Service.new("evmserverd").restart
-      @logger.info("Starting EVM server from failover monitor")
+      logger.info("Starting EVM server from failover monitor")
     end
 
     def stop_evmserverd

--- a/lib/manageiq/postgres_ha_admin/logging.rb
+++ b/lib/manageiq/postgres_ha_admin/logging.rb
@@ -1,0 +1,9 @@
+module ManageIQ
+module PostgresHaAdmin
+  module Logging
+    def logger
+      ManageIQ::PostgresHaAdmin.logger
+    end
+  end
+end
+end

--- a/lib/manageiq/postgres_ha_admin/null_logger.rb
+++ b/lib/manageiq/postgres_ha_admin/null_logger.rb
@@ -1,0 +1,13 @@
+require 'logger'
+
+module ManageIQ
+module PostgresHaAdmin
+  class NullLogger < Logger
+    def initialize(*_args)
+    end
+
+    def add(*_args, &_block)
+    end
+  end
+end
+end

--- a/spec/failover_databases_spec.rb
+++ b/spec/failover_databases_spec.rb
@@ -1,15 +1,12 @@
 describe ManageIQ::PostgresHaAdmin::FailoverDatabases do
-  let(:logger) { Logger.new(@logger_file) }
-  let(:failover_databases) { described_class.new(@yml_file.path, logger) }
+  let(:failover_databases) { described_class.new(@yml_file.path) }
 
   before do
     @yml_file = Tempfile.new('failover_databases.yml')
-    @logger_file = Tempfile.new('ha_admin.log')
   end
 
   after do
     @yml_file.close(true)
-    @logger_file.close(true)
   end
 
   describe "#active_databases_conninfo_hash" do

--- a/spec/failover_monitor_spec.rb
+++ b/spec/failover_monitor_spec.rb
@@ -9,16 +9,10 @@ describe ManageIQ::PostgresHaAdmin::FailoverMonitor do
     allow(conn).to receive(:finish)
     conn
   end
-  let(:logger) do
-    logger = double('Logger')
-    allow(logger).to receive_messages(:error => 'any', :info => 'any')
-    logger
-  end
   let(:failover_monitor) do
     expect(ManageIQ::PostgresHaAdmin::DatabaseYml).to receive(:new).and_return(db_yml)
     expect(ManageIQ::PostgresHaAdmin::FailoverDatabases).to receive(:new).and_return(failover_db)
-    failover_instance = described_class.new(:logger => logger)
-    failover_instance
+    described_class.new
   end
   let(:linux_admin) do
     linux_adm = double('LinuxAdmin')
@@ -35,8 +29,7 @@ failover_attempts: 20
       DOC
 
       File.write(ha_admin_yml_file.path, yml_data.to_yaml)
-      monitor_with_settings = described_class.new(:ha_admin_yml_file => ha_admin_yml_file.path,
-                                                  :logger            => logger)
+      monitor_with_settings = described_class.new(:ha_admin_yml_file => ha_admin_yml_file.path)
       ha_admin_yml_file.close(true)
 
       expect(described_class::FAILOVER_ATTEMPTS).not_to eq 20


### PR DESCRIPTION
This decouples the gem from our expected filesystem layout and also simplifies a lot of the object initialization and specs as we don't have to pass a logger object to everything.

This is the first part of my effort to make this gem usable for database clients which are not rails/database.yml based. While this PR doesn't push directly toward that goal, it does make this gem a bit more "normal" in the way it deals with logging.

Plus I'm going to be doing a sizable refactor so if we're breaking compatibility I might as well make other needed improvements while I'm at it. :smile: 

~~I'm also going to leave this WIP until we release a gem version with the PRs we need to move to repmgr 4. I don't want to tie that change up with the rest of the work I'm starting with this PR.~~

If we need to cut a gem version which doesn't include these commits we can tag a previous commit and push the gem from there. So I'm going to un-wip this.