### PR TITLE
Improve FailoverDatabases / ServerStore class

### DIFF
--- a/lib/manageiq-postgres_ha_admin.rb
+++ b/lib/manageiq-postgres_ha_admin.rb
@@ -3,7 +3,7 @@ require 'manageiq/postgres_ha_admin/version'
 require 'manageiq/postgres_ha_admin/logging'
 require 'manageiq/postgres_ha_admin/null_logger'
 
-require 'manageiq/postgres_ha_admin/failover_databases'
+require 'manageiq/postgres_ha_admin/server_store'
 require 'manageiq/postgres_ha_admin/failover_monitor'
 
 require 'manageiq/postgres_ha_admin/config_handler'

--- a/lib/manageiq/postgres_ha_admin/failover_monitor.rb
+++ b/lib/manageiq/postgres_ha_admin/failover_monitor.rb
@@ -17,11 +17,10 @@ module PostgresHaAdmin
     attr_accessor :failover_attempts, :db_check_frequency, :failover_check_frequency
 
     def initialize(db_yml_file: '/var/www/miq/vmdb/config/database.yml',
-                   failover_yml_file: '/var/www/miq/vmdb/config/failover_databases.yml',
                    ha_admin_yml_file: '/var/www/miq/vmdb/config/ha_admin.yml',
                    environment: 'production')
       @database_yml = RailsConfigHandler.new(:file_path => db_yml_file, :environment => environment)
-      @server_store = ServerStore.new(failover_yml_file)
+      @server_store = ServerStore.new
       initialize_settings(ha_admin_yml_file)
     end
 

--- a/lib/manageiq/postgres_ha_admin/server_store.rb
+++ b/lib/manageiq/postgres_ha_admin/server_store.rb
@@ -4,7 +4,7 @@ require 'pg/dsn_parser'
 
 module ManageIQ
 module PostgresHaAdmin
-  class FailoverDatabases
+  class ServerStore
     include Logging
 
     TABLE_NAME = "repmgr.nodes".freeze

--- a/lib/manageiq/postgres_ha_admin/server_store.rb
+++ b/lib/manageiq/postgres_ha_admin/server_store.rb
@@ -9,10 +9,10 @@ module PostgresHaAdmin
 
     TABLE_NAME = "repmgr.nodes".freeze
 
-    attr_reader :yml_file
+    attr_reader :servers_file
 
-    def initialize(yml_file)
-      @yml_file = yml_file
+    def initialize(servers_file)
+      @servers_file = servers_file
     end
 
     def active_databases_conninfo_hash
@@ -28,7 +28,7 @@ module PostgresHaAdmin
 
     def update_failover_yml(connection)
       arr_yml = query_repmgr(connection)
-      File.write(yml_file, arr_yml.to_yaml) unless arr_yml.empty?
+      File.write(servers_file, arr_yml.to_yaml) unless arr_yml.empty?
     rescue IOError => err
       logger.error("#{err.class}: #{err}")
       logger.error(err.backtrace.join("\n"))
@@ -66,8 +66,8 @@ module PostgresHaAdmin
     end
 
     def all_databases
-      return [] unless File.exist?(yml_file)
-      YAML.load_file(yml_file)
+      return [] unless File.exist?(servers_file)
+      YAML.load_file(servers_file)
     end
 
     def table_exists?(connection, table_name)

--- a/spec/failover_monitor_spec.rb
+++ b/spec/failover_monitor_spec.rb
@@ -2,7 +2,7 @@ require 'util/postgres_admin'
 
 describe ManageIQ::PostgresHaAdmin::FailoverMonitor do
   let(:config_handler) { double('ConfigHandler') }
-  let(:failover_db)    { double('FailoverDatabases') }
+  let(:server_store)   { double('ServerStore') }
 
   let(:connection) do
     conn = double("PGConnection")
@@ -11,7 +11,7 @@ describe ManageIQ::PostgresHaAdmin::FailoverMonitor do
   end
   let(:failover_monitor) do
     expect(ManageIQ::PostgresHaAdmin::RailsConfigHandler).to receive(:new).and_return(config_handler)
-    expect(ManageIQ::PostgresHaAdmin::FailoverDatabases).to receive(:new).and_return(failover_db)
+    expect(ManageIQ::PostgresHaAdmin::ServerStore).to receive(:new).and_return(server_store)
     described_class.new
   end
   let(:linux_admin) do
@@ -60,12 +60,12 @@ failover_attempts: 20
       end
 
       it "updates 'failover_databases.yml'" do
-        expect(failover_db).to receive(:update_failover_yml)
+        expect(server_store).to receive(:update_failover_yml)
         failover_monitor.monitor
       end
 
       it "does not stop evm server and does not execute failover" do
-        expect(failover_db).to receive(:update_failover_yml)
+        expect(server_store).to receive(:update_failover_yml)
         expect(linux_admin).not_to receive(:stop)
         expect(linux_admin).not_to receive(:restart)
         expect(failover_monitor).not_to receive(:execute_failover)
@@ -95,7 +95,7 @@ failover_attempts: 20
       it "does not update 'database.yml' and 'failover_databases.yml' if there is no master database avaiable" do
         failover_not_executed
         expect(failover_monitor).to receive(:database_in_recovery?).and_return(false, false, false).ordered
-        expect(failover_db).to receive(:host_is_repmgr_primary?).and_return(false, false, false).ordered
+        expect(server_store).to receive(:host_is_repmgr_primary?).and_return(false, false, false).ordered
         failover_monitor.monitor
       end
 
@@ -103,7 +103,7 @@ failover_attempts: 20
         failover_executed
         expect(failover_monitor).to receive(:raise_failover_event)
         expect(failover_monitor).to receive(:database_in_recovery?).and_return(false)
-        expect(failover_db).to receive(:host_is_repmgr_primary?).and_return(true)
+        expect(server_store).to receive(:host_is_repmgr_primary?).and_return(true)
         failover_monitor.monitor
       end
     end
@@ -120,7 +120,7 @@ failover_attempts: 20
         {:host => 'failover_host2.example.com', :password => 'mypassword'}
       ]
       settings_from_config_handler = {:host => 'host.example.com', :password => 'mypassword'}
-      expect(failover_db).to receive(:active_databases_conninfo_hash).and_return(active_servers_conninfo)
+      expect(server_store).to receive(:active_databases_conninfo_hash).and_return(active_servers_conninfo)
       expect(config_handler).to receive(:read).and_return(settings_from_config_handler)
       expect(failover_monitor.active_servers_conninfo).to match_array(expected_conninfo)
     end
@@ -138,16 +138,16 @@ failover_attempts: 20
 
   def failover_executed
     expect(linux_admin).to receive(:stop)
-    expect(failover_db).to receive(:active_databases_conninfo_hash).and_return(active_databases_conninfo)
-    expect(failover_db).to receive(:update_failover_yml)
+    expect(server_store).to receive(:active_databases_conninfo_hash).and_return(active_databases_conninfo)
+    expect(server_store).to receive(:update_failover_yml)
     expect(config_handler).to receive(:write)
     expect(linux_admin).to receive(:restart)
   end
 
   def failover_not_executed
     expect(linux_admin).to receive(:stop)
-    expect(failover_db).to receive(:active_databases_conninfo_hash).and_return(active_databases_conninfo)
-    expect(failover_db).not_to receive(:update_failover_yml)
+    expect(server_store).to receive(:active_databases_conninfo_hash).and_return(active_databases_conninfo)
+    expect(server_store).not_to receive(:update_failover_yml)
     expect(config_handler).not_to receive(:write)
     expect(linux_admin).not_to receive(:restart)
   end

--- a/spec/failover_monitor_spec.rb
+++ b/spec/failover_monitor_spec.rb
@@ -60,12 +60,12 @@ failover_attempts: 20
       end
 
       it "updates 'failover_databases.yml'" do
-        expect(server_store).to receive(:update_failover_yml)
+        expect(server_store).to receive(:update_servers)
         failover_monitor.monitor
       end
 
       it "does not stop evm server and does not execute failover" do
-        expect(server_store).to receive(:update_failover_yml)
+        expect(server_store).to receive(:update_servers)
         expect(linux_admin).not_to receive(:stop)
         expect(linux_admin).not_to receive(:restart)
         expect(failover_monitor).not_to receive(:execute_failover)
@@ -95,7 +95,7 @@ failover_attempts: 20
       it "does not update 'database.yml' and 'failover_databases.yml' if there is no master database avaiable" do
         failover_not_executed
         expect(failover_monitor).to receive(:database_in_recovery?).and_return(false, false, false).ordered
-        expect(server_store).to receive(:host_is_repmgr_primary?).and_return(false, false, false).ordered
+        expect(server_store).to receive(:host_is_primary?).and_return(false, false, false).ordered
         failover_monitor.monitor
       end
 
@@ -103,7 +103,7 @@ failover_attempts: 20
         failover_executed
         expect(failover_monitor).to receive(:raise_failover_event)
         expect(failover_monitor).to receive(:database_in_recovery?).and_return(false)
-        expect(server_store).to receive(:host_is_repmgr_primary?).and_return(true)
+        expect(server_store).to receive(:host_is_primary?).and_return(true)
         failover_monitor.monitor
       end
     end
@@ -120,7 +120,7 @@ failover_attempts: 20
         {:host => 'failover_host2.example.com', :password => 'mypassword'}
       ]
       settings_from_config_handler = {:host => 'host.example.com', :password => 'mypassword'}
-      expect(server_store).to receive(:active_databases_conninfo_hash).and_return(active_servers_conninfo)
+      expect(server_store).to receive(:connection_info_list).and_return(active_servers_conninfo)
       expect(config_handler).to receive(:read).and_return(settings_from_config_handler)
       expect(failover_monitor.active_servers_conninfo).to match_array(expected_conninfo)
     end
@@ -138,16 +138,16 @@ failover_attempts: 20
 
   def failover_executed
     expect(linux_admin).to receive(:stop)
-    expect(server_store).to receive(:active_databases_conninfo_hash).and_return(active_databases_conninfo)
-    expect(server_store).to receive(:update_failover_yml)
+    expect(server_store).to receive(:connection_info_list).and_return(active_databases_conninfo)
+    expect(server_store).to receive(:update_servers)
     expect(config_handler).to receive(:write)
     expect(linux_admin).to receive(:restart)
   end
 
   def failover_not_executed
     expect(linux_admin).to receive(:stop)
-    expect(server_store).to receive(:active_databases_conninfo_hash).and_return(active_databases_conninfo)
-    expect(server_store).not_to receive(:update_failover_yml)
+    expect(server_store).to receive(:connection_info_list).and_return(active_databases_conninfo)
+    expect(server_store).not_to receive(:update_servers)
     expect(config_handler).not_to receive(:write)
     expect(linux_admin).not_to receive(:restart)
   end

--- a/spec/server_store_spec.rb
+++ b/spec/server_store_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::PostgresHaAdmin::FailoverDatabases do
+describe ManageIQ::PostgresHaAdmin::ServerStore do
   let(:failover_databases) { described_class.new(@yml_file.path) }
 
   before do


### PR DESCRIPTION
This PR renames the FailoverDatabases class to ServerStore and makes some improvements and simplifications.

Mainly, it removes the need for a file containing the databases currently in the repmgr cluster by maintaining the list in memory and only queries for active databases (removing the need for methods prefaced by `active_`...)