### PR TITLE
Add a logical replication config handler

### DIFF
--- a/lib/manageiq-postgres_ha_admin.rb
+++ b/lib/manageiq-postgres_ha_admin.rb
@@ -9,6 +9,7 @@ require 'manageiq/postgres_ha_admin/failover_monitor'
 require 'manageiq/postgres_ha_admin/config_handler'
 require 'manageiq/postgres_ha_admin/config_handler/rails_config_handler'
 require 'manageiq/postgres_ha_admin/config_handler/pglogical_config_handler'
+require 'manageiq/postgres_ha_admin/config_handler/logical_replication_config_handler'
 
 module ManageIQ
   module PostgresHaAdmin

--- a/lib/manageiq/postgres_ha_admin/config_handler/logical_replication_config_handler.rb
+++ b/lib/manageiq/postgres_ha_admin/config_handler/logical_replication_config_handler.rb
@@ -1,0 +1,34 @@
+require 'pg'
+require 'pg/dsn_parser'
+
+module ManageIQ
+module PostgresHaAdmin
+  class LogicalReplicationConfigHandler < ConfigHandler
+    attr_reader :subscription, :conn_info
+
+    def initialize(options = {})
+      @subscription = options[:subscription]
+      @conn_info    = options[:conn_info]
+    end
+
+    def name
+      "Logical Replication subscription #{subscription} Config Handler"
+    end
+
+    def read
+      conn = PG::Connection.open(@conn_info)
+      dsn = conn.exec_params(<<~SQL, [@subscription]).first["subconninfo"]
+        SELECT subconninfo
+        FROM pg_subscription
+        WHERE subname = $1
+      SQL
+      PG::DSNParser.new.parse(dsn)
+    end
+
+    def write(_params)
+      # Nothing to do here as the expectation is that the user will 
+      # remove and re-add the subscription in the after failover callback
+    end
+  end
+end
+end


### PR DESCRIPTION
This is similar to the pglogical config handler, but selects the
conninfo from the pg_subscription table rather than the pglogical
extension tables