### PR TITLE
Removing deprecated Gemnasium badge

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -34,6 +34,7 @@ engines:
   rubocop:
     enabled: true
     config: '.rubocop_cc.yml'
+    channel: 'rubocop-0-69'
 prepare:
   fetch:
   - url: "https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Build Status](https://travis-ci.org/ManageIQ/manageiq-postgres_ha_admin.svg)](https://travis-ci.org/ManageIQ/manageiq-postgres_ha_admin)
 [![Code Climate](https://codeclimate.com/github/ManageIQ/manageiq-postgres_ha_admin.svg)](https://codeclimate.com/github/ManageIQ/manageiq-postgres_ha_admin)
 [![Test Coverage](https://codeclimate.com/github/ManageIQ/manageiq-postgres_ha_admin/badges/coverage.svg)](https://codeclimate.com/github/ManageIQ/manageiq-postgres_ha_admin/coverage)
-[![Dependency Status](https://gemnasium.com/ManageIQ/manageiq-postgres_ha_admin.svg)](https://gemnasium.com/ManageIQ/manageiq-postgres_ha_admin)
 [![Security](https://hakiri.io/github/ManageIQ/manageiq-postgres_ha_admin/master.svg)](https://hakiri.io/github/ManageIQ/manageiq-postgres_ha_admin/master)
 
 [![Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ManageIQ/manageiq-postgres_ha_admin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)


### PR DESCRIPTION
Functionality has been replaced by GitHub's dependency graph and security alerts.

Also, added rubocop channel to .codeclimate.yml