### PR TITLE
Don't attempt a database failover without a known standby

### DIFF
--- a/lib/manageiq/postgres_ha_admin/config_handler.rb
+++ b/lib/manageiq/postgres_ha_admin/config_handler.rb
@@ -27,9 +27,12 @@ module PostgresHaAdmin
       @before_failover_cb&.call
     end
 
+    # Upon successful failover
     def do_after_failover(new_primary_conn_info)
       @after_failover_cb&.call(new_primary_conn_info)
     end
+
+    # If needed, we can add an unsuccessful failover hook
   end
 end
 end

--- a/lib/manageiq/postgres_ha_admin/failover_monitor.rb
+++ b/lib/manageiq/postgres_ha_admin/failover_monitor.rb
@@ -35,9 +35,12 @@ module PostgresHaAdmin
           handler.do_before_failover
 
           new_conn_info = execute_failover(handler, server_store)
+
           if new_conn_info
+            # Upon success, we pass a connection hash
             handler.do_after_failover(new_conn_info)
           else
+            # Add failover_failed hook if we have a use case in the future
             logger.error("#{log_prefix(__callee__)} Failover failed")
           end
         rescue => e
@@ -89,6 +92,10 @@ module PostgresHaAdmin
     end
 
     def execute_failover(handler, server_store)
+      # TODO: Instead of returning false, we should raise:
+      # "No active standby"
+      # "Standby in recovery"
+      # "Exhausted all failover retry attempts" exceptions
       unless any_known_standby?(handler, server_store)
         logger.error("#{log_prefix(__callee__)} Cannot attempt failover without a known active standby.  Please verify the database.yml and ensure the database is started.")
         return false

--- a/spec/failover_monitor_spec.rb
+++ b/spec/failover_monitor_spec.rb
@@ -3,6 +3,8 @@ describe ManageIQ::PostgresHaAdmin::FailoverMonitor do
   let(:config_handler2) { double('ConfigHandler2', :name => "Other config handler") }
   let(:server_store)    { double('ServerStore') }
   let(:server_store2)   { double('ServerStore2') }
+  let(:server_store)    { double('ServerStore',  :servers => [{:type => 'primary'}, {:type => 'standby'}]) }
+  let(:server_store2)   { double('ServerStore2', :servers => [{:type => 'primary'}, {:type => 'standby'}]) }
 
   before do
     allow(ManageIQ::PostgresHaAdmin::ServerStore).to receive(:new).and_return(server_store, server_store2)
@@ -16,6 +18,7 @@ describe ManageIQ::PostgresHaAdmin::FailoverMonitor do
 
   describe "#initialize" do
     it "override default failover settings with settings loaded from provided config file" do
+      require 'tempfile'
       ha_admin_yml_file = Tempfile.new('ha_admin.yml')
       yml_data = YAML.load(<<-DOC)
 ---
@@ -35,6 +38,35 @@ failover_attempts: 20
       expect(subject.failover_attempts).to eq described_class::FAILOVER_ATTEMPTS
       expect(subject.db_check_frequency).to eq described_class::DB_CHECK_FREQUENCY
       expect(subject.failover_check_frequency).to eq described_class::FAILOVER_CHECK_FREQUENCY
+    end
+  end
+
+  describe "#any_known_standby?" do
+    let(:standby_handler) { double(:name => "standby_test", :read => {:host => '203.0.113.1'}) }
+    let(:server_list) do
+      [
+        {:type => 'primary', :active => true, :host => '203.0.113.1', :user => 'root', :dbname => 'vmdb_test'},
+        {:type => 'standby', :active => true, :host => '203.0.113.2', :user => 'root', :dbname => 'vmdb_test'}
+      ]
+    end
+
+    it "is true with a standby that's not the current database" do
+      expect(subject.send(:any_known_standby?, standby_handler, double(:servers => server_list))).to be_truthy
+    end
+
+    it "is false with 2 primaries, no standby" do
+      server_list.last[:type] = 'primary'
+      expect(subject.send(:any_known_standby?, standby_handler, double(:servers => server_list))).to be_falsy
+    end
+
+    it "is false with no known primary or standby" do
+      server_list = []
+      expect(subject.send(:any_known_standby?, standby_handler, double(:servers => server_list))).to be_falsy
+    end
+
+    it "is false with only standby as current database" do
+      server_list.last[:host] = '203.0.113.1'
+      expect(subject.send(:any_known_standby?, standby_handler, double(:servers => server_list))).to be_falsy
     end
   end
 

--- a/spec/failover_monitor_spec.rb
+++ b/spec/failover_monitor_spec.rb
@@ -125,8 +125,10 @@ failover_attempts: 20
       end
 
       it "calls the before failover callback before failover attempt" do
+        conn_info = {:dbname => "blah", :user => "root"}
         expect(config_handler).to receive(:do_before_failover).ordered
-        expect(subject).to receive(:execute_failover).ordered
+        expect(subject).to receive(:execute_failover).ordered.and_return(conn_info)
+        expect(config_handler).to receive(:do_after_failover).ordered.with(conn_info)
         subject.monitor
       end
 
@@ -182,7 +184,7 @@ failover_attempts: 20
     expect(server_store).to receive(:connection_info_list).and_return(active_databases_conninfo)
     expect(server_store).not_to receive(:update_servers)
     expect(config_handler).not_to receive(:write)
-    expect(config_handler).not_to receive(:do_after_failover)
+    expect(config_handler).to receive(:do_after_failover).never
   end
 
   def stub_monitor_constants


### PR DESCRIPTION
(You might want to hide whitespace changes)

* Don't attempt a database failover without a known standby

Fixes #34

Related to https://github.com/ManageIQ/manageiq/pull/22115 https://github.com/ManageIQ/manageiq/pull/22116

I've tested https://github.com/ManageIQ/manageiq/pull/22116 along with https://github.com/ManageIQ/manageiq-postgres_ha_admin/pull/36 in the following scenarios:
* Failover to standby
* Failover with no standby (evmserverd exits with error, failover monitor skips failover and logs an error, manageiq-db-ready waits for the configured database to be accessible and restarts evmserverd when old db comes back up)
* Failback (failover from old standby back to primary) (primary was reintroduced as a standby before we fail back)

Instead of trying for 10 minutes, we fail quicker (up to 2 minutes based on the database check frequency)

```
Sep 19 16:57:02 app.localdomain systemd[1]: evmserverd.service: Main process exited, code=exited, status=1/FAILURE
Sep 19 16:57:02 app.localdomain systemd[1]: evmserverd.service: Failed with result 'exit-code'.
Sep 19 16:57:02 app.localdomain systemd[1]: evmserverd.service: Service RestartSec=100ms expired, scheduling restart.
Sep 19 16:57:02 app.localdomain systemd[1]: evmserverd.service: Scheduled restart job, restart counter is at 2.
Sep 19 16:57:02 app.localdomain systemd[1]: Stopped EVM server daemon.
Sep 19 16:57:02 app.localdomain systemd[1]: Starting ManageIQ DB Ready...
Sep 19 16:57:02 app.localdomain manageiq-db-ready[2788]: 10.0.2.11 5432 - not accepting connections
Sep 19 16:57:12 app.localdomain manageiq-db-ready[2788]: 10.0.2.11 5432 - not accepting connections
Sep 19 16:57:22 app.localdomain manageiq-db-ready[2788]: 10.0.2.11 5432 - not accepting connections
Sep 19 16:57:32 app.localdomain manageiq-db-ready[2788]: 10.0.2.11 5432 - not accepting connections
Sep 19 16:57:42 app.localdomain manageiq-db-ready[2788]: 10.0.2.11 5432 - not accepting connections
Sep 19 16:57:52 app.localdomain manageiq-db-ready[2788]: 10.0.2.11 5432 - not accepting connections
Sep 19 16:58:02 app.localdomain manageiq-db-ready[2788]: 10.0.2.11 5432 - not accepting connections
Sep 19 16:58:12 app.localdomain manageiq-db-ready[2788]: 10.0.2.11 5432 - not accepting connections
Sep 19 16:58:13 app.localdomain evm[2756]: ERROR -- evm: (PostgresHaAdmin#pg_connection) Failed to establish PG connection: could not connect to server: Connection refused
Sep 19 16:58:13 app.localdomain evm[2756]: ERROR -- evm: (PostgresHaAdmin#monitor) Primary Database is not available for Rails production Config Handler. Starting to execute failover...
Sep 19 16:58:13 app.localdomain evm[2756]: ERROR -- evm: (PostgresHaAdmin#execute_failover) Cannot attempt failover without a known active standby.  Please verify the database.yml and ensure the database is started.
Sep 19 16:58:13 app.localdomain evm[2756]: ERROR -- evm: (PostgresHaAdmin#monitor) Failover failed
```

Additionally, with https://github.com/ManageIQ/manageiq/pull/22115, we now will correctly sit and wait with the existing database.yml settings pointing to the failed database until manageiq-db-ready says it's up and running again...

```
# Continued from above:
Sep 19 16:58:22 app.localdomain manageiq-db-ready[2788]: 10.0.2.11 5432 - not accepting connections
Sep 19 16:58:32 app.localdomain manageiq-db-ready[2788]: 10.0.2.11 5432 - accepting connections
Sep 19 16:58:32 app.localdomain manageiq-db-ready[2788]: vmdb_production is up and running
Sep 19 16:58:32 app.localdomain systemd[1]: manageiq-db-ready.service: Succeeded.
Sep 19 16:58:32 app.localdomain systemd[1]: Started ManageIQ DB Ready.
Sep 19 16:58:32 app.localdomain systemd[1]: Started EVM server daemon.
```

