### PR TITLE
5 minute db checks is too long, use 2 minutes

### DIFF
--- a/lib/manageiq/postgres_ha_admin/failover_monitor.rb
+++ b/lib/manageiq/postgres_ha_admin/failover_monitor.rb
@@ -7,7 +7,7 @@ module PostgresHaAdmin
     include Logging
 
     FAILOVER_ATTEMPTS = 10
-    DB_CHECK_FREQUENCY = 300
+    DB_CHECK_FREQUENCY = 120
     FAILOVER_CHECK_FREQUENCY = 60
     attr_accessor :failover_attempts, :db_check_frequency, :failover_check_frequency
     attr_reader :config_handlers


### PR DESCRIPTION
Followup to https://github.com/ManageIQ/manageiq/pull/22106

It's not really required to change this because the ha_admin.yml value trumps this but we might as well since we know 5 minutes is too infrequent.

Suggested here: https://github.com/ManageIQ/manageiq/pull/22106#issuecomment-1248201370