### PR TITLE
Improve failover logging

### DIFF
--- a/lib/manageiq/postgres_ha_admin/failover_monitor.rb
+++ b/lib/manageiq/postgres_ha_admin/failover_monitor.rb
@@ -110,7 +110,7 @@ module PostgresHaAdmin
         with_each_standby_connection(handler, server_store) do |connection, params|
           next if database_in_recovery?(connection)
           next unless server_store.host_is_primary?(params[:host], connection)
-          logger.info("#{log_prefix(__callee__)} Failing over for #{handler.name} to server using conninfo: #{params.reject { |k, _v| k == :password }}")
+          logger.info("#{log_prefix(__callee__)} Failing over for #{handler.name} to server using conninfo: #{server_store.sanitized_connection_parameters(params)}")
           server_store.update_servers(connection, handler.name)
           handler.write(params)
           return params
@@ -123,7 +123,7 @@ module PostgresHaAdmin
 
     def with_each_standby_connection(handler, server_store)
       active_servers_conninfo(handler, server_store).each do |params|
-        logger.info("#{log_prefix(__callee__)} Trying standby server for #{handler.name} using conninfo: #{params.reject { |k, _v| k == :password }}")
+        logger.info("#{log_prefix(__callee__)} Checking active server for #{handler.name} using conninfo: #{server_store.sanitized_connection_parameters(params)}")
         connection = pg_connection(params)
         next if connection.nil?
         begin

--- a/lib/manageiq/postgres_ha_admin/failover_monitor.rb
+++ b/lib/manageiq/postgres_ha_admin/failover_monitor.rb
@@ -38,12 +38,8 @@ module PostgresHaAdmin
 
           new_conn_info = execute_failover(handler, server_store)
 
-          if new_conn_info
-            # Upon success, we pass a connection hash
-            handler.do_after_failover(new_conn_info)
-          else
-            # Add failover_failed hook if we have a use case in the future
-          end
+          # Upon success, we pass a connection hash
+          handler.do_after_failover(new_conn_info) if new_conn_info
         rescue => e
           logger.error("#{log_prefix(__callee__)} Received #{e.class} error while monitoring #{handler.name}: #{e.message}")
           logger.error(e.backtrace)

--- a/lib/manageiq/postgres_ha_admin/failover_monitor.rb
+++ b/lib/manageiq/postgres_ha_admin/failover_monitor.rb
@@ -31,6 +31,7 @@ module PostgresHaAdmin
             next
           end
 
+          log_settings
           logger.error("#{log_prefix(__callee__)} Primary Database is not available for #{handler.name}. Starting to execute failover...")
           handler.do_before_failover
 
@@ -70,6 +71,10 @@ module PostgresHaAdmin
 
     private
 
+    def log_settings
+      logger.info("#{log_prefix(__callee__)} Current HA settings: FAILOVER_ATTEMPTS=#{@failover_attempts} DB_CHECK_FREQUENCY=#{@db_check_frequency} FAILOVER_CHECK_FREQUENCY=#{@failover_check_frequency}")
+    end
+
     def initialize_settings(ha_admin_yml_file)
       ha_admin_yml = {}
       begin
@@ -81,7 +86,7 @@ module PostgresHaAdmin
       @failover_attempts = ha_admin_yml['failover_attempts'] || FAILOVER_ATTEMPTS
       @db_check_frequency = ha_admin_yml['db_check_frequency'] || DB_CHECK_FREQUENCY
       @failover_check_frequency = ha_admin_yml['failover_check_frequency'] || FAILOVER_CHECK_FREQUENCY
-      logger.info("#{log_prefix(__callee__)} FAILOVER_ATTEMPTS=#{@failover_attempts} DB_CHECK_FREQUENCY=#{@db_check_frequency} FAILOVER_CHECK_FREQUENCY=#{@failover_check_frequency}")
+      log_settings
     end
 
     def any_known_standby?(handler, server_store)

--- a/lib/manageiq/postgres_ha_admin/failover_monitor.rb
+++ b/lib/manageiq/postgres_ha_admin/failover_monitor.rb
@@ -123,6 +123,7 @@ module PostgresHaAdmin
 
     def with_each_standby_connection(handler, server_store)
       active_servers_conninfo(handler, server_store).each do |params|
+        logger.info("#{log_prefix(__callee__)} Trying standby server for #{handler.name} using conninfo: #{params.reject { |k, _v| k == :password }}")
         connection = pg_connection(params)
         next if connection.nil?
         begin

--- a/lib/manageiq/postgres_ha_admin/failover_monitor.rb
+++ b/lib/manageiq/postgres_ha_admin/failover_monitor.rb
@@ -32,6 +32,7 @@ module PostgresHaAdmin
           end
 
           log_settings
+          server_store.log_current_server_store(handler.name)
           logger.error("#{log_prefix(__callee__)} Primary Database is not available for #{handler.name}. Starting to execute failover...")
           handler.do_before_failover
 

--- a/lib/manageiq/postgres_ha_admin/server_store.rb
+++ b/lib/manageiq/postgres_ha_admin/server_store.rb
@@ -26,7 +26,7 @@ module PostgresHaAdmin
       new_servers = query_repmgr(connection)
       if servers_changed?(new_servers)
         log_current_server_store(handler_name)
-        logger.info("#{log_prefix(__callee__)} Updating servers cache to #{new_servers} for #{handler_name}")
+        logger.info("#{log_prefix(__callee__)} Updating servers cache to #{sanitized_servers_array(new_servers)} for #{handler_name}")
         @servers = new_servers
       end
     rescue IOError => err
@@ -43,11 +43,19 @@ module PostgresHaAdmin
       false
     end
 
-    private
-
     def log_current_server_store(handler_name)
-      logger.info("#{log_prefix(__callee__)} Current servers cache: #{@servers} for #{handler_name}")
+      logger.info("#{log_prefix(__callee__)} Current servers cache: #{sanitized_servers_array(@servers)} for #{handler_name}")
     end
+
+    def sanitized_servers_array(server_array)
+      server_array.collect { |p| sanitized_connection_parameters(p) }
+    end
+
+    def sanitized_connection_parameters(params)
+      params.reject { |k, _v| k.to_s == "password" }
+    end
+
+    private
 
     def servers_changed?(new_servers)
       ((servers - new_servers) + (new_servers - servers)).any?

--- a/lib/manageiq/postgres_ha_admin/server_store.rb
+++ b/lib/manageiq/postgres_ha_admin/server_store.rb
@@ -22,10 +22,11 @@ module PostgresHaAdmin
       end
     end
 
-    def update_servers(connection)
+    def update_servers(connection, handler_name = "unspecified handler")
       new_servers = query_repmgr(connection)
       if servers_changed?(new_servers)
-        logger.info("#{log_prefix(__callee__)} Updating servers cache to #{new_servers}")
+        log_current_server_store(handler_name)
+        logger.info("#{log_prefix(__callee__)} Updating servers cache to #{new_servers} for #{handler_name}")
         @servers = new_servers
       end
     rescue IOError => err
@@ -43,6 +44,10 @@ module PostgresHaAdmin
     end
 
     private
+
+    def log_current_server_store(handler_name)
+      logger.info("#{log_prefix(__callee__)} Current servers cache: #{@servers} for #{handler_name}")
+    end
 
     def servers_changed?(new_servers)
       ((servers - new_servers) + (new_servers - servers)).any?

--- a/spec/failover_monitor_spec.rb
+++ b/spec/failover_monitor_spec.rb
@@ -1,9 +1,7 @@
 describe ManageIQ::PostgresHaAdmin::FailoverMonitor do
   let(:config_handler)  { double('ConfigHandler', :name => "Test config handler") }
   let(:config_handler2) { double('ConfigHandler2', :name => "Other config handler") }
-  let(:server_store)    { double('ServerStore') }
-  let(:server_store2)   { double('ServerStore2') }
-  let(:server_store)    { double('ServerStore',  :servers => [{:type => 'primary'}, {:type => 'standby'}]) }
+  let(:server_store)    { double('ServerStore',  :log_current_server_store => nil, :servers => [{:type => 'primary'}, {:type => 'standby'}]) }
   let(:server_store2)   { double('ServerStore2', :servers => [{:type => 'primary'}, {:type => 'standby'}]) }
 
   before do

--- a/spec/failover_monitor_spec.rb
+++ b/spec/failover_monitor_spec.rb
@@ -1,7 +1,7 @@
 describe ManageIQ::PostgresHaAdmin::FailoverMonitor do
   let(:config_handler)  { double('ConfigHandler', :name => "Test config handler") }
   let(:config_handler2) { double('ConfigHandler2', :name => "Other config handler") }
-  let(:server_store)    { double('ServerStore',  :log_current_server_store => nil, :servers => [{:type => 'primary'}, {:type => 'standby'}]) }
+  let(:server_store)    { double('ServerStore',  :log_current_server_store => nil, :sanitized_connection_parameters => {}, :servers => [{:type => 'primary'}, {:type => 'standby'}]) }
   let(:server_store2)   { double('ServerStore2', :servers => [{:type => 'primary'}, {:type => 'standby'}]) }
 
   before do

--- a/spec/server_store_spec.rb
+++ b/spec/server_store_spec.rb
@@ -43,13 +43,13 @@ describe ManageIQ::PostgresHaAdmin::ServerStore do
 
     describe "#update_servers" do
       it "updates the servers list" do
-        subject.update_servers(@connection)
+        subject.update_servers(@connection, "test handler")
 
         expect(subject.servers).to eq initial_db_list
 
         add_new_record
 
-        subject.update_servers(@connection)
+        subject.update_servers(@connection, "test handler")
         expect(subject.servers).to eq new_db_list
       end
     end


### PR DESCRIPTION
This PR came to be after seeing failover logging that looked like this:

```
 INFO -- evm: MIQ(Vmdb::Initializer.init) Initializing Application: Program Name: bin/rails, PID: 65805, ENV['EVMSERVER']:
 INFO -- evm: MIQ(Vmdb::Initializer.log_db_connectable) Successfully connected to the database.
 INFO -- evm: FAILOVER_ATTEMPTS=5 DB_CHECK_FREQUENCY=20 FAILOVER_CHECK_FREQUENCY=10
 INFO -- evm: MIQ(EvmDatabase.configure_rails_handler) Configuring database failover for /var/www/miq/vmdb/config/database.yml's production environment
 INFO -- evm: MIQ(EvmDatabase.run_failover_monitor) Starting database failover monitor
 INFO -- evm: Updating servers cache to [{:type=>"primary", :active=>true, :host=>"db1", :user=>"root", :dbname=>"vmdb_production"}, {:type=>"standby", :active=>true, :host=>"db2", :user=>"root", :dbname=>"vmdb_production"}, {:type=>"standby", :active=>true, :host=>"db3", :user=>"root", :dbname=>"vmdb_production"}]
ERROR -- evm: Failed to establish PG connection: could not connect to server: Connection refused
ERROR -- evm: Primary Database is not available for Rails production Config Handler. Starting to execute failover...
ERROR -- evm: Failed to establish PG connection: could not connect to server: Connection refused
ERROR -- evm: Failed to establish PG connection: could not connect to server: Connection refused
ERROR -- evm: Failed to establish PG connection: could not connect to server: Connection refused
ERROR -- evm: Failed to establish PG connection: could not connect to server: Connection refused
ERROR -- evm: Failed to establish PG connection: could not connect to server: Connection refused
ERROR -- evm: Failover failed
ERROR -- evm: Failed to establish PG connection: could not connect to server: Connection refused
ERROR -- evm: Primary Database is not available for Rails production Config Handler. Starting to execute failover...
ERROR -- evm: Failed to establish PG connection: could not connect to server: Connection refused
 INFO -- evm: Failing over to server using conninfo: {:dbname=>"vmdb_production", :user=>"root", :port=>5432, :host=>"db3"}
 INFO -- evm: Updating servers cache to [{:type=>"primary", :active=>true, :host=>"db3", :user=>"root", :dbname=>"vmdb_production"}, {:type=>"standby", :active=>true, :host=>"db2", :user=>"root", :dbname=>"vmdb_production"}]
```

The goals are to:
* Clarify the handler we're looking at since we have one failover handler for the application (rails) and one for the region replication (for removing and adding a new subscription) so it's possible we have 2 completely different sets of primary/standby combinations. We weren't logging the handler consistently before.
* Log the current server store or snapshot of the current handler's primary/standby configuration BEFORE we attempt failover.  It's possible logs have been rotated or truncated, we shouldn't rely on a message that occurred many days earlier, when the process was started.
* Improve logging of multiple standbys since we don't know which will be promoted so we keep trying the list of standbys until we find one that has been promoted.  This was not obvious when looking at the logs above.

Below are examples of 1 primary, 1 standby logging when failover occurs and you reintroduce the failed node as a new standby to the promoted standby.

### Before

```
 INFO -- evm: (PostgresHaAdmin#initialize_settings) FAILOVER_ATTEMPTS=10 DB_CHECK_FREQUENCY=120 FAILOVER_CHECK_FREQUENCY=60
 INFO -- evm: MIQ(EvmDatabase.configure_rails_handler) Configuring database failover for /var/www/miq/vmdb/config/database.yml's production environment
 INFO -- evm: MIQ(EvmDatabase.run_failover_monitor) Starting database failover monitor
 INFO -- evm: (PostgresHaAdmin#update_servers) Updating servers cache to [{:type=>"primary", :active=>true, :host=>"10.0.2.20", :user=>"root", :dbname=>"vmdb_production"}, {:type=>"standby", :active=>true, :host=>"10.0.2.21", :user=>"root", :dbname=>"vmdb_production"}]
ERROR -- evm: (PostgresHaAdmin#pg_connection) Failed to establish PG connection: could not connect to server: Connection refused
                                               Is the server running on host "10.0.2.20" and accepting
                                               TCP/IP connections on port 5432?
ERROR -- evm: (PostgresHaAdmin#monitor) Primary Database is not available for Rails production Config Handler. Starting to execute failover...
ERROR -- evm: (PostgresHaAdmin#pg_connection) Failed to establish PG connection: could not connect to server: Connection refused
                                               Is the server running on host "10.0.2.20" and accepting
                                               TCP/IP connections on port 5432?
 INFO -- evm: (PostgresHaAdmin#execute_failover) Failing over to server using conninfo: {:dbname=>"vmdb_production", :user=>"root", :port=>5432, :host=>"10.0.2.21"}
 INFO -- evm: (PostgresHaAdmin#update_servers) Updating servers cache to [{:type=>"primary", :active=>true, :host=>"10.0.2.21", :user=>"root", :dbname=>"vmdb_production"}]
 INFO -- evm: (PostgresHaAdmin#update_servers) Updating servers cache to [{:type=>"primary", :active=>true, :host=>"10.0.2.21", :user=>"root", :dbname=>"vmdb_production"}, {:type=>"standby", :active=>true, :host=>"10.0.2.20", :user=>"root", :dbname=>"vmdb_production"}]
```


### After

```
 INFO -- evm: (PostgresHaAdmin#log_settings) Current HA settings: FAILOVER_ATTEMPTS=10 DB_CHECK_FREQUENCY=120 FAILOVER_CHECK_FREQUENCY=60
 INFO -- evm: MIQ(EvmDatabase.configure_rails_handler) Configuring database failover for /var/www/miq/vmdb/config/database.yml's production environment
 INFO -- evm: MIQ(EvmDatabase.run_failover_monitor) Starting database failover monitor
 INFO -- evm: (PostgresHaAdmin#log_current_server_store) Current servers cache: [] for Rails production Config Handler
 INFO -- evm: (PostgresHaAdmin#update_servers) Updating servers cache to [{:type=>"primary", :active=>true, :host=>"10.0.2.21", :user=>"root", :dbname=>"vmdb_production"}, {:type=>"standby", :active=>true, :host=>"10.0.2.20", :user=>"root", :dbname=>"vmdb_production"}] for Rails production Config Handler
ERROR -- evm: (PostgresHaAdmin#pg_connection) Failed to establish PG connection: could not connect to server: Connection refused
                                               Is the server running on host "10.0.2.21" and accepting
                                               TCP/IP connections on port 5432?
 INFO -- evm: (PostgresHaAdmin#log_settings) Current HA settings: FAILOVER_ATTEMPTS=10 DB_CHECK_FREQUENCY=120 FAILOVER_CHECK_FREQUENCY=60
 INFO -- evm: (PostgresHaAdmin#log_current_server_store) Current servers cache: [{:type=>"primary", :active=>true, :host=>"10.0.2.21", :user=>"root", :dbname=>"vmdb_production"}, {:type=>"standby", :active=>true, :host=>"10.0.2.20", :user=>"root", :dbname=>"vmdb_production"}] for Rails production Config Handler
ERROR -- evm: (PostgresHaAdmin#monitor) Primary Database is not available for Rails production Config Handler. Starting to execute failover...
 INFO -- evm: (PostgresHaAdmin#with_each_standby_connection) Checking active server for Rails production Config Handler using conninfo: {:dbname=>"vmdb_production", :user=>"root", :port=>5432, :host=>"10.0.2.21"}
ERROR -- evm: (PostgresHaAdmin#pg_connection) Failed to establish PG connection: could not connect to server: Connection refused
                                               Is the server running on host "10.0.2.21" and accepting
                                               TCP/IP connections on port 5432?
 INFO -- evm: (PostgresHaAdmin#with_each_standby_connection) Checking active server for Rails production Config Handler using conninfo: {:dbname=>"vmdb_production", :user=>"root", :port=>5432, :host=>"10.0.2.20"}
 INFO -- evm: (PostgresHaAdmin#execute_failover) Failing over for Rails production Config Handler to server using conninfo: {:dbname=>"vmdb_production", :user=>"root", :port=>5432, :host=>"10.0.2.20"}
 INFO -- evm: (PostgresHaAdmin#log_current_server_store) Current servers cache: [{:dbname=>"vmdb_production", :user=>"root", :port=>5432, :host=>"10.0.2.21"}, {:dbname=>"vmdb_production", :user=>"root", :port=>5432, :host=>"10.0.2.20"}] for Rails production Config Handler
 INFO -- evm: (PostgresHaAdmin#update_servers) Updating servers cache to [{:type=>"primary", :active=>true, :host=>"10.0.2.20", :user=>"root", :dbname=>"vmdb_production"}] for Rails production Config Handler
 INFO -- evm: (PostgresHaAdmin#log_current_server_store) Current servers cache: [{:type=>"primary", :active=>true, :host=>"10.0.2.20", :user=>"root", :dbname=>"vmdb_production"}] for Rails production Config Handler
 INFO -- evm: (PostgresHaAdmin#update_servers) Updating servers cache to [{:type=>"primary", :active=>true, :host=>"10.0.2.20", :user=>"root", :dbname=>"vmdb_production"}, {:type=>"standby", :active=>true, :host=>"10.0.2.21", :user=>"root", :dbname=>"vmdb_production"}] for Rails production Config Handler
```

Note:
1) We log the current settings at startup and before attempting a failover
2) We log the current in memory server cache before we update it and after, such as when we add or remove a primary or standby or swap roles.
3) When failover is needed, we log each server we're about to try so the `Connection refused` error has more context as to what's being attempted.  Note, it starts with the primary as it really doesn't want to failover.  So failover looks like:
  a) primary fails
  b) we try primary again
  c) we move onto the first standby
  d) we try each remaining standby