### PR TITLE
Update ruby rails dependencies (breaking change)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,13 +12,17 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '2.7'
         - '3.0'
         - '3.1'
+        - '3.2'
+        - '3.3'
         rails-version:
-        - '6.0'
-        - '6.1'
         - '7.0'
+        - '7.1'
+        - '7.2'
+        exclude:
+        - ruby-version: '3.0'
+          rails-version: '7.2'
     services:
       postgres:
         image: manageiq/postgresql:13

--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,12 @@ gemspec
 
 minimum_version =
   case ENV['TEST_RAILS_VERSION']
-  when "6.0"
-    "~>6.0.4"
-  when "7.0"
-    "~>7.0.8"
+  when "7.2"
+    "~>7.2.1"
+  when "7.1"
+    "~>7.1.4"
   else
-    "~>6.1.4"
+    "~>7.0.8"
   end
 
 gem "activesupport", minimum_version

--- a/manageiq-postgres_ha_admin.gemspec
+++ b/manageiq-postgres_ha_admin.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.5.8"
+  spec.required_ruby_version = ">= 3.0"
 
   spec.add_runtime_dependency "activesupport",     ">=7.0.8", "<8.0"
   spec.add_runtime_dependency "awesome_spawn",     "~> 1.4"

--- a/manageiq-postgres_ha_admin.gemspec
+++ b/manageiq-postgres_ha_admin.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.5.8"
 
-  spec.add_runtime_dependency "activesupport",     ">=5.0", "<7.1"
+  spec.add_runtime_dependency "activesupport",     ">=7.0.8", "<8.0"
   spec.add_runtime_dependency "awesome_spawn",     "~> 1.4"
   spec.add_runtime_dependency "manageiq-password", "< 2"
   spec.add_runtime_dependency "pg"


### PR DESCRIPTION
### Use core minimum but allow 7.0/7.1/7.2 since core sets upper limit
### Drop end of life rubies and rails and add new versions

Ensure we're testing and supporting community supported
versions.

Drop:
* ruby 2.7
* rails 6.0
* rails 6.1

Add:
* ruby 3.2
* ruby 3.3
* rails 7.1
* rails 7.2

Note: ruby 3.0 is not difficult to keep maintaining for now but it's on the chopping block.